### PR TITLE
form border color roles - container roles

### DIFF
--- a/M2TWinForms/Controls/Window/M2TForm.cs
+++ b/M2TWinForms/Controls/Window/M2TForm.cs
@@ -180,9 +180,13 @@ public partial class M2TForm : Form, IThemedControl
         return role switch
         {
             M2TFormBorderColorRoleSelection.Primary => ColorRoles.Primary,
+            M2TFormBorderColorRoleSelection.PrimaryContainer => ColorRoles.Primary,
             M2TFormBorderColorRoleSelection.Secondary => ColorRoles.Secondary,
+            M2TFormBorderColorRoleSelection.SecondaryContainer => ColorRoles.SecondaryContainer,
             M2TFormBorderColorRoleSelection.Tertiary => ColorRoles.Tertiary,
+            M2TFormBorderColorRoleSelection.TertiaryContainer => ColorRoles.TertiaryContainer,
             M2TFormBorderColorRoleSelection.Error => ColorRoles.Error,
+            M2TFormBorderColorRoleSelection.ErrorContainer => ColorRoles.ErrorContainer,
             M2TFormBorderColorRoleSelection.Surface => ColorRoles.Surface,
             M2TFormBorderColorRoleSelection.SurfaceContainer => ColorRoles.SurfaceContainer,
             M2TFormBorderColorRoleSelection.SurfaceContainerHighest => ColorRoles.SurfaceContainerHighest,


### PR DESCRIPTION
added missing mappings for form border color roles

* PrimaryContainer
* SecondaryContainer
* TertiaryContainer
* ErrorContainer

missing the mappings would cause an exception to be thrown, crashing the application